### PR TITLE
Don't use new Function() when lineWidthStyler is not used

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ AFRAME.registerComponent('meshline', {
   schema: {
     color: { default: '#000' },
     lineWidth: { default: 10 },
-    lineWidthStyler: { default: '1' },
+    lineWidthStyler: { default: null },
     sizeAttenuation: { default: 0 },
     near: { default: 0.1 },
     far: { default: 1000 },
@@ -95,7 +95,9 @@ AFRAME.registerComponent('meshline', {
       );
     });
     
-    var widthFn = new Function ('p', 'return ' + this.data.lineWidthStyler);
+    var widthFn = this.data.lineWidthStyler
+      ? new Function('p', 'return ' + this.data.lineWidthStyler)
+      : function() { return 1; };
     //? try {var w = widthFn(0);} catch(e) {warn(e);}
     var line = new THREE.MeshLine();
     line.setGeometry( geometry, widthFn );

--- a/index.js
+++ b/index.js
@@ -95,8 +95,10 @@ AFRAME.registerComponent('meshline', {
       );
     });
     
-    var widthFn = this.data.lineWidthStyler && this.data.lineWidthStyler > 0
-      ? new Function('p', 'return ' + this.data.lineWidthStyler)
+    var widthFn = (
+      typeof this.data.lineWidthStyler === 'string' &&
+      this.data.lineWidthStyler.length > 0
+    ) ? new Function('p', 'return ' + this.data.lineWidthStyler)
       : function() { return 1; };
     //? try {var w = widthFn(0);} catch(e) {warn(e);}
     var line = new THREE.MeshLine();

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ AFRAME.registerComponent('meshline', {
   schema: {
     color: { default: '#000' },
     lineWidth: { default: 10 },
-    lineWidthStyler: { default: null },
+    lineWidthStyler: { default: '' },
     sizeAttenuation: { default: 0 },
     near: { default: 0.1 },
     far: { default: 1000 },
@@ -95,7 +95,7 @@ AFRAME.registerComponent('meshline', {
       );
     });
     
-    var widthFn = this.data.lineWidthStyler
+    var widthFn = this.data.lineWidthStyler && this.data.lineWidthStyler > 0
       ? new Function('p', 'return ' + this.data.lineWidthStyler)
       : function() { return 1; };
     //? try {var w = widthFn(0);} catch(e) {warn(e);}


### PR DESCRIPTION
This PR changes the behaviour of the component such that it does not invoke `new Function()` for the default value of `lineWidthStyler`. This is important for browser environments when the page is loaded with `Content-Security-Policy` headers without `unsafe-eval` - right now, the meshline component is not usable in such environments.

After merging the PR, the meshline component avoids calling `new Function()` when `lineWidthStyler` is not set explicitly, and uses a default line styler function instead.